### PR TITLE
Split out some functionality to new Config class

### DIFF
--- a/lib/git_switch.rb
+++ b/lib/git_switch.rb
@@ -1,3 +1,4 @@
 require_relative 'git_switch/switcher'
 require_relative 'git_switch/git_helper'
 require_relative 'git_switch/options'
+require_relative 'git_switch/config'

--- a/lib/git_switch/config.rb
+++ b/lib/git_switch/config.rb
@@ -1,0 +1,65 @@
+require 'yaml'
+
+module GitSwitch
+  class Config
+    attr_reader :profiles, :selected_profile
+    def initialize(args)
+      @profiles = load!
+      @args = args
+      @selected_profile = get_profile(args)
+    end
+
+    def get_profile(args)
+      args.detect {|a| !a.start_with? '-'}
+    end
+
+    def name
+      profiles[selected_profile]["name"]
+    end
+
+    def username
+      profiles[selected_profile]["username"]
+    end
+
+    def email
+      profiles[selected_profile]["email"]
+    end
+
+    def ssh
+      profiles[selected_profile]["ssh"]
+    end
+
+    def profile
+      @selected_profile
+    end
+
+    def valid_profile?
+      if profiles.has_key?(selected_profile)
+        return true
+      else
+        puts "Profile '#{selected_profile}' not found!"
+        return false
+      end
+    end
+
+    def print_list
+      profiles = @profiles.map do |key, value|
+        prefix = value["username"] == current_git_username ? "=>" : "  "
+        "#{prefix} #{key}"
+      end
+      puts profiles
+      puts "\n# => - current" if @profiles.any? {|key, value| value["username"] == current_git_username}
+    end
+
+    private
+
+    def load!
+      # TODO: RCR - Handle missing or empty config file
+      YAML.load_file(File.expand_path('~/.gitswitch')) || {}
+    end
+
+    def current_git_username
+      `git config user.username`.chomp
+    end
+  end
+end

--- a/spec/lib/git_switch/config_spec.rb
+++ b/spec/lib/git_switch/config_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe GitSwitch::Config do
+  describe 'valid_profile?' do
+    context 'when profile is configured' do
+      let(:config) { GitSwitch::Config.new(['personal']) }
+      it 'returns true' do
+        expect(config.valid_profile?).to be true
+      end
+    end
+
+    context 'when profile is not configured' do
+      let(:config) { GitSwitch::Config.new(['foo']) }
+      let(:expected_output) { "Profile 'foo' not found!\n" }
+      it 'returns false' do
+        expect(config.valid_profile?).to be false
+      end
+
+      it 'prints error message' do
+        expect{config.valid_profile?}.to output(expected_output).to_stdout
+      end
+    end
+  end
+
+  describe '#print_list' do
+    let(:config) { GitSwitch::Config.new(['-l']) }
+    context 'when profiles have been configured' do
+      context 'when no profiles are active' do
+        let(:expected_output) { "   personal\n   work\n" }
+        it 'outputs available profiles' do
+          expect{config.print_list}.to output(expected_output).to_stdout
+        end
+      end
+
+      context 'when a profile is active' do
+        before do
+          allow(config).to receive(:current_git_username).and_return('johnnyfive')
+        end
+        let(:expected_output) { "=> personal\n   work\n\n# => - current\n" }
+        it 'indicates the active profile' do
+          expect{config.print_list}.to output(expected_output).to_stdout
+        end
+      end
+    end
+
+    context 'when no profiles have been configured' do
+      let(:expected_output) { '' }
+      before do
+        # unstub
+        allow(File).to receive(:expand_path).and_call_original
+        allow(File).to receive(:expand_path).and_return(File.expand_path('spec/fixtures/.empty'))
+      end
+
+      it 'outputs an empty string' do
+        expect{config.print_list}.to output(expected_output).to_stdout
+      end
+    end
+  end
+end

--- a/spec/lib/git_switch/switcher_spec.rb
+++ b/spec/lib/git_switch/switcher_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe GitSwitch::Switcher do
     context 'in list mode' do
       let(:switcher) { GitSwitch::Switcher.new(['-l']) }
       it 'calls print_list' do
-        expect(switcher).to receive(:print_list)
+        expect(switcher.config).to receive(:print_list)
         switcher.run
       end
     end
@@ -129,7 +129,7 @@ RSpec.describe GitSwitch::Switcher do
       end
 
       it 'checks for valid profile' do
-        expect(switcher).to receive(:valid_profile?)
+        expect(switcher.config).to receive(:valid_profile?)
         switcher.run
       end
 
@@ -211,41 +211,6 @@ RSpec.describe GitSwitch::Switcher do
     end
   end
 
-  describe '#print_list' do
-    let(:switcher) { GitSwitch::Switcher.new(['-l']) }
-    context 'when profiles have been configured' do
-      context 'when no profiles are active' do
-        let(:expected_output) { "   personal\n   work\n" }
-        it 'outputs available profiles' do
-          expect{switcher.print_list}.to output(expected_output).to_stdout
-        end
-      end
-
-      context 'when a profile is active' do
-        before do
-          allow(switcher).to receive(:current_git_username).and_return('johnnyfive')
-        end
-        let(:expected_output) { "=> personal\n   work\n\n# => - current\n" }
-        it 'indicates the active profile' do
-          expect{switcher.print_list}.to output(expected_output).to_stdout
-        end
-      end
-    end
-
-    context 'when no profiles have been configured' do
-      let(:expected_output) { '' }
-      before do
-        # unstub
-        allow(File).to receive(:expand_path).and_call_original
-        allow(File).to receive(:expand_path).and_return(File.expand_path('spec/fixtures/.empty'))
-      end
-
-      it 'outputs an empty string' do
-        expect{switcher.print_list}.to output(expected_output).to_stdout
-      end
-    end
-  end
-
   describe '#print_usage' do
     let(:switcher) { GitSwitch::Switcher.new([]) }
     let(:expected_output) do
@@ -268,27 +233,6 @@ RSpec.describe GitSwitch::Switcher do
 
     it 'outputs usage details' do
       expect{switcher.print_usage}.to output(expected_output).to_stdout
-    end
-  end
-
-  describe 'valid_profile?' do
-    context 'when profile is configured' do
-      let(:switcher) { GitSwitch::Switcher.new(['personal']) }
-      it 'returns true' do
-        expect(switcher.valid_profile?).to be true
-      end
-    end
-
-    context 'when profile is not configured' do
-      let(:switcher) { GitSwitch::Switcher.new(['foo']) }
-      let(:expected_output) { "Profile 'foo' not found!\n" }
-      it 'returns false' do
-        expect(switcher.valid_profile?).to be false
-      end
-
-      it 'prints error message' do
-        expect{switcher.valid_profile?}.to output(expected_output).to_stdout
-      end
     end
   end
 


### PR DESCRIPTION
The Switcher class is growing too large. The new Config class will be responsible for interfacing with the .gitswitch config file and managing the configured profiles.