### PR TITLE
Update handling of ssh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 Git Switch is a command line utility to easily switch between multiple git profiles. It uses a `.gitswitch` YAML file to configure each profile (name, username, and email) and ssh key.
 
+## Prerequisites
+
+This gem has been developed for, and only tested on, Mac OS.
+
+Additionally, it requires git version 2.10+. Run `git --version` to check your currently install version. If you are using homebrew, you can install a newer version of git with `brew upgrade git`.
+
 ## Installation
 
 This gem is not intended to be installed via a Gemfile. Instead, install it yourself:

--- a/lib/git_switch/config.rb
+++ b/lib/git_switch/config.rb
@@ -13,10 +13,6 @@ module GitSwitch
       args.detect {|a| !a.start_with? '-'}
     end
 
-    def name
-      profiles[selected_profile]["name"]
-    end
-
     def username
       profiles[selected_profile]["username"]
     end
@@ -25,8 +21,16 @@ module GitSwitch
       profiles[selected_profile]["email"]
     end
 
+    def name
+      profiles[selected_profile]["name"]
+    end
+
     def ssh
       profiles[selected_profile]["ssh"]
+    end
+
+    def ssh_command
+      "ssh -i #{ssh}"
     end
 
     def profile

--- a/lib/git_switch/version.rb
+++ b/lib/git_switch/version.rb
@@ -1,3 +1,3 @@
 module GitSwitch
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/lib/git_switch/config_spec.rb
+++ b/spec/lib/git_switch/config_spec.rb
@@ -1,6 +1,40 @@
 require 'spec_helper'
 
 RSpec.describe GitSwitch::Config do
+  describe 'profile attributes' do
+    let(:config) { GitSwitch::Config.new(['personal']) }
+
+    describe '#username' do
+      it 'returns the username for the selected profile' do
+        expect(config.username).to eq 'johnnyfive'
+      end
+    end
+
+    describe '#email' do
+      it 'returns the email for the selected profile' do
+        expect(config.email).to eq 'me@johnsmith.com'
+      end
+    end
+
+    describe '#name' do
+      it 'returns the name for the selected profile' do
+        expect(config.name).to eq 'Johnny Smith'
+      end
+    end
+
+    describe '#ssh' do
+      it 'returns the ssh path for the selected profile' do
+        expect(config.ssh).to eq '~/.ssh/id_rsa'
+      end
+    end
+
+    describe '#ssh_command' do
+      it 'returns the ssh command for the selected profile' do
+        expect(config.ssh_command).to eq 'ssh -i ~/.ssh/id_rsa'
+      end
+    end
+  end
+
   describe 'valid_profile?' do
     context 'when profile is configured' do
       let(:config) { GitSwitch::Config.new(['personal']) }

--- a/spec/lib/git_switch/switcher_spec.rb
+++ b/spec/lib/git_switch/switcher_spec.rb
@@ -210,20 +210,9 @@ RSpec.describe GitSwitch::Switcher do
 
     let(:switcher) { GitSwitch::Switcher.new(['personal']) }
 
-    context 'when run with -g flag' do
-      let(:switcher) { GitSwitch::Switcher.new(['personal', '-g']) }
-      it 'calls set_git_config with global flag' do
-        expect(switcher).to receive(:set_git_config).with('--global')
-        switcher.run
-      end
-    end
-
-    context 'when run with --global flag' do
-      let(:switcher) { GitSwitch::Switcher.new(['personal', '--global']) }
-      it 'calls set_git_config with global flag' do
-        expect(switcher).to receive(:set_git_config).with('--global')
-        switcher.run
-      end
+    it 'calls set_git_config' do
+      expect(switcher).to receive(:set_git_config)
+      switcher.run
     end
 
     it 'calls set_ssh' do


### PR DESCRIPTION
Use git config core.sshCommand to manage active ssh key.

Fixes issues #11, #17, and #47